### PR TITLE
Improve process handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+### Fixed
+- Close the connection if the session actor dies.
+- Clarify documentation about `updates` properly functioning only in the process that created the client.
+
+## [1.0.0] - 2025-01-18
+
+### Added
+- Initial release with basic functionality.
+
+[Unreleased]: https://github.com/sbergen/spoke/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/sbergen/spoke/releases/tag/v1.0.0

--- a/spoke/src/spoke.gleam
+++ b/spoke/src/spoke.gleam
@@ -364,6 +364,13 @@ pub fn start_session_with_ms_keep_alive(
   Client(client, updates, config)
 }
 
+/// For testability, as there should be no other way to crash the actor.
+@internal
+pub fn unlink_and_crash(client: Client) {
+  process.unlink(process.subject_owner(client.subject))
+  process.send(client.subject, Crash)
+}
+
 type Config {
   Config(
     client_id: String,
@@ -392,6 +399,7 @@ type OperationResult(a) =
   Result(a, OperationError)
 
 type Message {
+  Crash
   Connect(Bool, Option(PublishData))
   Publish(PublishData)
   Subscribe(
@@ -443,6 +451,7 @@ fn init(
 
 fn run_client(message: Message, state: State) -> actor.Next(Message, State) {
   case message {
+    Crash -> panic as "Requested actor to crash"
     Connect(clean_session, will) -> handle_connect(state, clean_session, will)
     ProcessReceived(packet) -> process_packet(state, packet)
     Publish(data) -> handle_outgoing_publish(state, data)

--- a/spoke/src/spoke.gleam
+++ b/spoke/src/spoke.gleam
@@ -232,6 +232,9 @@ pub fn restore_session(
 
 /// Returns a `Subject` for receiving client updates
 /// (received messages and connection state changes).
+/// NOTE: This function is provided for convenience
+/// as receiving updates only works from the process that created the client!
+/// Future versions of spoke might support receiving updates in multiple processes. 
 pub fn updates(client: Client) -> Subject(Update) {
   client.updates
 }

--- a/spoke/test/error_handling_test.gleam
+++ b/spoke/test/error_handling_test.gleam
@@ -1,0 +1,11 @@
+import fake_server
+import spoke
+
+pub fn connection_is_closed_if_actor_crashes_test() {
+  let #(client, server) =
+    fake_server.set_up_connected_client(clean_session: True)
+
+  spoke.unlink_and_crash(client)
+
+  fake_server.expect_connection_closed(server)
+}


### PR DESCRIPTION
- Close the connection if the session actor dies.
- Clarify documentation about `updates` properly functioning only in the process that created the client.