### PR TITLE
Don't panic on unexpected message ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-04-16
+
+### Fixed
+- Don't panic when a ping is scheduled around the same time as we are sending
+  another packet.
 
 ## [1.0.1] - 2025-02-15
 
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release with basic functionality.
 
-[Unreleased]: https://github.com/sbergen/spoke/compare/v1.0.1...HEAD
-[1.0.0]: https://github.com/sbergen/spoke/releases/tag/v1.0.1
+[Unreleased]: https://github.com/sbergen/spoke/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/sbergen/spoke/releases/tag/v1.0.2
+[1.0.1]: https://github.com/sbergen/spoke/releases/tag/v1.0.1
 [1.0.0]: https://github.com/sbergen/spoke/releases/tag/v1.0.0

--- a/spoke/gleam.toml
+++ b/spoke/gleam.toml
@@ -1,5 +1,5 @@
 name = "spoke"
-version = "1.0.1"
+version = "1.0.2"
 
 description = "A Gleam MQTT 3.1.1 client for the Erlang runtime."
 licences = ["Apache-2.0"]


### PR DESCRIPTION
It seems like it's possible to get a message ordering where we are sending a packet when the ping timer has already expired, but the message has not yet been processed.

Should resolve #6 