### PR TITLE
Stop using `try_call`, as it's going away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- `wait_for_publishes_to_finish` will panic instead of returning an error
+  if the client is killed during this time.
+  This is due to `try_call` being removed from `gleam_erlang`.
+
 ## [1.0.2] - 2025-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- `wait_for_publishes_to_finish` will panic instead of returning an error
-  if the client is killed during this time.
+- `subscribe`, `unsubscribe`, and `wait_for_publishes_to_finish`
+  will panic instead of returning `Error(KilledDuringOperation)`
+  if the client is killed during the call.
+  `KilledDuringOperation` is removed.
   This is due to `try_call` being removed from `gleam_erlang`.
 
 ## [1.0.2] - 2025-04-16

--- a/spoke/src/spoke.gleam
+++ b/spoke/src/spoke.gleam
@@ -105,8 +105,6 @@ pub type OperationError {
   OperationTimedOut
   /// We received unexpected data from the server, and will disconnect.
   ProtocolViolation
-  /// The client actor was killed while the operation was in progress.
-  KilledDuringOperation
 }
 
 /// The result of a subscribe operation

--- a/spoke/test/publish_test.gleam
+++ b/spoke/test/publish_test.gleam
@@ -200,3 +200,17 @@ pub fn previous_clean_session_is_discarded_test() {
 
   fake_server.disconnect(client, server)
 }
+
+pub fn wait_for_publishes_timeout_test() {
+  let #(client, server) =
+    fake_server.set_up_connected_client(clean_session: True)
+
+  let data = spoke.PublishData("topic", <<"payload">>, spoke.AtLeastOnce, False)
+  spoke.publish(client, data)
+
+  let assert Error(Nil) = spoke.wait_for_publishes_to_finish(client, 10)
+    as "waiting for publishes should time out if not acked"
+
+  fake_server.drop_incoming_data(server)
+  fake_server.disconnect(client, server)
+}


### PR DESCRIPTION
Add graceful timeouts of `subscribe`, `unsubscribe` and `wait_for_publishes_to_finish` manually, as `try_call` will be going way in the next major `gleam_erlang` release.